### PR TITLE
Fixed uboot patches

### DIFF
--- a/patches/uboot/0001-cpu-info.patch
+++ b/patches/uboot/0001-cpu-info.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm/mach-rockchip/rv1106/rv1106.c b/arch/arm/mach-rockchip/rv1106/rv1106.c
-index b5abd2955..b94842c70 100644
+index f7306c6..550711a 100644
 --- a/arch/arm/mach-rockchip/rv1106/rv1106.c
 +++ b/arch/arm/mach-rockchip/rv1106/rv1106.c
-@@ -654,3 +654,12 @@ int rk_board_fdt_fixup(const void *blob)
+@@ -677,3 +677,12 @@ int rk_board_fdt_fixup(const void *blob)
  
  	return 0;
  }

--- a/patches/uboot/0003-tiny-vnsprintf.patch
+++ b/patches/uboot/0003-tiny-vnsprintf.patch
@@ -1,9 +1,9 @@
 diff --git a/lib/tiny-printf.c b/lib/tiny-printf.c
-index ebef92fc9f..62e6381961 100644
+index 312b46a..9825bb5 100644
 --- a/lib/tiny-printf.c
 +++ b/lib/tiny-printf.c
-@@ -366,6 +366,22 @@ int sprintf(char *buf, const char *fmt, ...)
-        return ret;
+@@ -364,6 +364,22 @@ int sprintf(char *buf, const char *fmt, ...)
+ 	return info.outstr - buf;
  }
  
 +#if CONFIG_IS_ENABLED(LOG)

--- a/patches/uboot/0004-configs-rv1106.patch
+++ b/patches/uboot/0004-configs-rv1106.patch
@@ -1,5 +1,5 @@
 diff --git a/include/configs/rv1106_common.h b/include/configs/rv1106_common.h
-index dc927a8..7922f7b 100644
+index f25ba22..7ad5f77 100644
 --- a/include/configs/rv1106_common.h
 +++ b/include/configs/rv1106_common.h
 @@ -35,7 +35,7 @@
@@ -11,7 +11,7 @@ index dc927a8..7922f7b 100644
  #define CONFIG_SPL_BSS_START_ADDR	0x001fe000
  #define CONFIG_SPL_BSS_MAX_SIZE		0x20000
  #define CONFIG_SPL_STACK		0x001fe000
-@@ -89,14 +89,11 @@
+@@ -92,14 +92,11 @@
  
  #undef RKIMG_BOOTCOMMAND
  #ifdef CONFIG_FIT_SIGNATURE
@@ -28,7 +28,7 @@ index dc927a8..7922f7b 100644
  /* Update define for tiny image */
  #ifdef CONFIG_ROCKCHIP_IMAGE_TINY
  #undef RKIMG_BOOTCOMMAND
-@@ -108,7 +105,6 @@
+@@ -111,7 +108,6 @@
  #undef CONFIG_GZIP
  /* TODO: #define CONFIG_LIB_HW_RAND */
  

--- a/patches/uboot/0006-pinctrl-rockchip-nullptr-check.patch
+++ b/patches/uboot/0006-pinctrl-rockchip-nullptr-check.patch
@@ -1,8 +1,8 @@
 diff --git a/drivers/pinctrl/pinctrl-rockchip.c b/drivers/pinctrl/pinctrl-rockchip.c
-index ee3e4f3ab5..cd3c432702 100644
+index ccee25e..6627aa8 100644
 --- a/drivers/pinctrl/pinctrl-rockchip.c
 +++ b/drivers/pinctrl/pinctrl-rockchip.c
-@@ -829,7 +829,7 @@ static void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
+@@ -874,7 +874,7 @@ static void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
  {
  	struct rockchip_pinctrl_priv *priv = bank->priv;
  	struct rockchip_pin_ctrl *ctrl = priv->ctrl;
@@ -11,7 +11,7 @@ index ee3e4f3ab5..cd3c432702 100644
  	int i;
  
  	for (i = 0; i < ctrl->niomux_recalced; i++) {
-@@ -842,6 +842,9 @@ static void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
+@@ -887,6 +887,9 @@ static void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
  	if (i >= ctrl->niomux_recalced)
  		return;
  
@@ -21,7 +21,7 @@ index ee3e4f3ab5..cd3c432702 100644
  	*reg = data->reg;
  	*mask = data->mask;
  	*bit = data->bit;
-@@ -1561,7 +1564,7 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
+@@ -1606,7 +1609,7 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
  {
  	struct rockchip_pinctrl_priv *priv = bank->priv;
  	struct rockchip_pin_ctrl *ctrl = priv->ctrl;
@@ -30,7 +30,7 @@ index ee3e4f3ab5..cd3c432702 100644
  	int i;
  
  	for (i = 0; i < ctrl->niomux_routes; i++) {
-@@ -1574,6 +1577,10 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
+@@ -1619,6 +1622,10 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
  	if (i >= ctrl->niomux_routes)
  		return ROUTE_TYPE_INVALID;
  

--- a/patches/uboot/0007-cmd-process-return-type.patch
+++ b/patches/uboot/0007-cmd-process-return-type.patch
@@ -1,0 +1,15 @@
+diff --git a/include/command.h b/include/command.h
+index 681084b..8889634 100644
+--- a/include/command.h
++++ b/include/command.h
+@@ -139,8 +139,8 @@ enum command_ret_t {
+  *			number of ticks the command took to complete.
+  * @return 0 if the command succeeded, 1 if it failed
+  */
+-int cmd_process(int flag, int argc, char * const argv[],
+-			       int *repeatable, unsigned long *ticks);
++enum command_ret_t cmd_process(int flag, int argc, char *const argv[],
++				int *repeatable, unsigned long *ticks);
+ 
+ void fixup_cmdtable(cmd_tbl_t *cmdtp, int size);
+ 


### PR DESCRIPTION
Hi Ole! 

First of: Thanks so much for putting this work together!

I experimented a bit using the commands from the Dockerfile (and with buildroot 2025.02.14),  but unfortunately, the patches no longer apply cleanly to the current state of rockchips U-Boot codebase. Since the project has evolved a bit, these will need to be rebased to work with the latest version.

One additional patch is necessary to fix an issue as described [here](https://lists.denx.de/pipermail/u-boot/2022-August/490520.html)

I tried fixing the patches for the [latest commit](https://github.com/rockchip-linux/u-boot/commit/aeec6f2bfd5ce0cfcdfe0ffc7f84d9d143683856) on the next-dev branch here.

Maybe, the commit hash of the u-boot could be included in the defconfig instead of the branch name?